### PR TITLE
Création de la requête pour l'historique des flux

### DIFF
--- a/app/Http/Controllers/EditController.php
+++ b/app/Http/Controllers/EditController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Command;
+use App\Models\StockReception;
+use Illuminate\Http\JsonResponse;
+
+class EditController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return JsonResponse
+     */
+    public function editAllFlux()
+    {
+        $commands = Command::with(['state', 'store'])->orderBy('delivery_date', 'desc')->get();
+        $stockReception = StockReception::with(['supplier'])->orderBy('reception_date','desc')->get();
+        return response()->json(['Receptions' => $stockReception, 'Commands' => $commands]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,6 +88,8 @@ Route::group([
     Route::post('/product_commands', 'ProductCommandController@create');
     Route::put('/product_commands/{id}', 'ProductCommandController@update');
     Route::delete('/product_commands/{id}','ProductCommandController@destroy');
+
+    Route::get('/historics_flux', 'EditController@editAllFlux');
 });
 
 //Auth routes


### PR DESCRIPTION
Création d'un controller pour les requêtes de flux. Création de la
première méthode renvoyant en une seule fois toutes les réceptions et
toutes les commandes, chacune trié par date.